### PR TITLE
Make sure empty string args passed to git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## 0.1.1 - In development
+### Fixed
+- Allow for passing along empty arguments during expansion.
+
 ## 0.1.0 - 2015-04-22
 Initial public release.
 

--- a/commands/expand/expand.go
+++ b/commands/expand/expand.go
@@ -59,6 +59,14 @@ func Process(args []string) string {
 	var processedArgs []string
 	for _, arg := range expand(args) {
 		processed := escape(evaluateEnvironment(arg))
+
+		// if we still ended up with a totally blank arg, escape it here.
+		// we handle this as a special case rather than in expandArg because we
+		// don't want it to be subject to normal escaping.
+		if processed == "" {
+			processed = "''"
+		}
+
 		processedArgs = append(processedArgs, processed)
 	}
 

--- a/commands/expand/expand_test.go
+++ b/commands/expand/expand_test.go
@@ -46,3 +46,14 @@ func TestExpandArg(t *testing.T) {
 		}
 	}
 }
+
+// Process expansion with an empty arg should be quoted so it doesnt get lost,
+// special case handling that occurs in final step (to avoid escaping).
+func TestProcessEmpty(t *testing.T) {
+	actual := Process([]string{"a", "", "c"})
+	expected := "a\t''\tc"
+
+	if actual != expected {
+		t.Fatalf("ExpandEmpty: expected %v, actual %v", expected, actual)
+	}
+}

--- a/features/command_expand.feature
+++ b/features/command_expand.feature
@@ -63,3 +63,12 @@ Feature: command expansion at command line
     Then the stdout from "scmpuff expand 1" should contain "/tmp/aruba/xxx.jpg"
     When I successfully run `scmpuff expand -r -- 1`
     Then the stdout from "scmpuff expand -r -- 1" should contain "../../xxx.jpg"
+
+  Scenario: Don't trim empty string args when expanding command
+    There are certain situations where someone would want to actually pass an
+    empty string arg, so we need to make sure we don't trim that out.
+    Essentially we want to avoid the error condition reported here:
+    https://github.com/ndbroadbent/scm_breeze/issues/167
+
+    When I successfully run `scmpuff expand -- hub commit --allow-empty --allow-empty-message -m ''`
+    Then the output should match /hub\tcommit\t--allow-empty\t--allow-empty-message\t-m\t\'\'/


### PR DESCRIPTION
Since the eventual output of expanded args is going to be handled via shell wrapper, need to make sure totally empty args are effectively quoted so they don’t get ignored.

This addresses the use case identified in SCM Breeze in ndbroadbent/scm_breeze#167.