### PR TITLE
Allow semicolons to be used in commit messages

### DIFF
--- a/commands/expand/expand.go
+++ b/commands/expand/expand.go
@@ -50,7 +50,7 @@ Takes a list of digits (1 4 5) or numeric ranges (1-5) or even both.`,
 
 var expandArgDigitMatcher = regexp.MustCompile("^[0-9]{0,4}$")
 var expandArgRangeMatcher = regexp.MustCompile("^([0-9]+)-([0-9]+)$")
-var shellEscaper = regexp.MustCompile("([\\^()\\[\\]<>' \"])")
+var shellEscaper = regexp.MustCompile("([\\^()\\[\\]<>' \";])")
 
 // Process expands args and performs all substitution, etc.
 //

--- a/features/command_expand.feature
+++ b/features/command_expand.feature
@@ -52,6 +52,17 @@ Feature: command expansion at command line
       | so(dumb).jpg   | so\(dumb\).jpg   |
       | hi mom.txt     | hi\ mom.txt      |
       | "x.txt         | \"x.txt          |
+      | wt;af.gif      | wt\;af.gif       |
+
+  Scenario: Semicolons in commit messages
+    Given a git repository named "whatever"
+      And I cd to "whatever"
+      And a 4 byte file named "a.txt"
+      And I successfully run the following commands:
+        | git add a.txt                               |
+      When I successfully run `scmpuff expand -- git commit -m "foo; bar"`
+      Then the stderr should not contain anything
+        And the output should match /git\tcommit\t-m\tfoo\\;\\ bar/
 
   Scenario: Allow user to specify --relative paths
     Given a directory named "foo"


### PR DESCRIPTION
If I'm committing two semi-related bits of functionality, I'll often use a semicolon in the commit message to separate them: 

`git commit -m "Fix escaping of semicolons; unit test to ensure it works."`

`scmpuff` didn't treat the semicolon as a special character. This results in abridged commit messages, and errors in the output: 

```
[master (root-commit) cc10013] Fix escaping of semicolons
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 a.txt
bash:  unit test to ensure it works.: command not found
```

This PR fixes that. I also tested that actual semicolons are unaffected (eg. `git commit -m "Foo; bar"; say "Commit finished"`), but I couldn't see a good way to write a test for that case. 