### PR TITLE
Allow scmpuff_status to handle detached git states

### DIFF
--- a/commands/status/process.go
+++ b/commands/status/process.go
@@ -66,14 +66,25 @@ func ExtractBranch(bs []byte) *BranchInfo {
 	return &b
 }
 
-func decodeBranchName(bs []byte) string {
-	re := regexp.MustCompile(`^## (?:Initial commit on )?(\S+?)(?:\.{3}|$)`)
-	m := re.FindSubmatch(bs)
-	if m == nil {
+func decodeBranchName(bs []byte) (branch string) {
+	branchRegex := regexp.MustCompile(`^## (?:Initial commit on )?(\S+?)(?:\.{3}|$)`)
+	headRegex := regexp.MustCompile(`^## (HEAD \(no branch\))`)
+
+	branchMatch := branchRegex.FindSubmatch(bs)
+	if branchMatch != nil {
+		branch = string(branchMatch[1])
+	}
+
+	headMatch := headRegex.FindSubmatch(bs)
+	if headMatch != nil {
+		branch = string(headMatch[1])
+	}
+
+	if headMatch == nil && branchMatch == nil {
 		log.Fatalf("Failed to parse branch name for output: [%s]", bs)
 	}
 
-	return string(m[1])
+	return
 }
 
 func decodeBranchPosition(bs []byte) (ahead, behind int) {

--- a/commands/status/process_test.go
+++ b/commands/status/process_test.go
@@ -229,6 +229,14 @@ var testCasesExtractBranch = []struct {
 		[]byte("## 3.0...origin/3.0 [ahead 1]"),
 		&BranchInfo{name: "3.0", ahead: 1, behind: 0},
 	},
+	{
+		[]byte("## HEAD (no branch)"),
+		&BranchInfo{name: "HEAD (no branch)", ahead: 0, behind: 0},
+	},
+	{
+		[]byte("## HEAD (no branch)UU both_modified.txt"),
+		&BranchInfo{name: "HEAD (no branch)", ahead: 0, behind: 0},
+	},
 }
 
 func TestExtractBranch(t *testing.T) {

--- a/features/command_status.feature
+++ b/features/command_status.feature
@@ -248,3 +248,27 @@ Feature: status command
     Then the output should match /both deleted: *\[[0-9]*\] *renamed_file/
     Then the output should match /added by them: *\[[0-9]*\] *renamed_file_on_branch/
     Then the output should match /added by us: *\[[0-9]*\] *renamed_file_on_master/
+
+  Scenario: Status for a handling a conflict when rebasing
+    Given I am in a git repository
+    And a file named "file_with_conflict" with:
+      """
+      original content
+      """
+    And I successfully run `git add file_with_conflict`
+    And I successfully run `git commit -m "Original content"`
+    
+    When I switch to git branch "foobar"
+    And I append to "file_with_conflict" with "a change from foobar"
+    And I successfully run `git add file_with_conflict`
+    And I successfully run `git commit -m "Edited in branch foobar"`
+
+    When I switch to existing git branch "master"
+    And I append to "file_with_conflict" with "a change from master"
+    And I successfully run `git add file_with_conflict`
+    And I successfully run `git commit -m "Edited in branch master"`
+
+    When I switch to existing git branch "foobar"
+    And I run `git rebase master`
+    And I successfully run `scmpuff status`
+    Then the output should match /On branch: HEAD \(no branch\)/

--- a/features/step_definitions/scmpuff_steps.rb
+++ b/features/step_definitions/scmpuff_steps.rb
@@ -28,6 +28,12 @@ Given(/^I switch to git branch "([^"]*)"$/) do |branch_name|
   }
 end
 
+Given(/^I switch to existing git branch "([^"]*)"$/) do |branch_name|
+  steps %Q{
+    Given I successfully run `git checkout #{branch_name}`
+  }
+end
+
 Given(/^I clone "(.*?)" to "(.*?)"$/) do |r1, r2|
   steps %Q{
     Given I successfully run `git clone #{r1}/.git #{r2}`

--- a/features/step_definitions/scmpuff_steps.rb
+++ b/features/step_definitions/scmpuff_steps.rb
@@ -2,46 +2,46 @@ require 'fileutils'
 require 'aruba/api'
 
 Given(/^a git repository named "([^"]*)"$/) do |repo_name|
-  steps %Q{
+  steps %(
     Given I successfully run `git init --quiet #{repo_name}`
-  }
+  )
 end
 
 Given(/^I am in a git repository named "([^"]*)"$/) do |repo_name|
-  steps %Q{
+  steps %(
     Given a git repository named "#{repo_name}"
     And I cd to "#{repo_name}"
-  }
+  )
 end
 
 Given(/^I am in a git repository$/) do
   repo_name = 'mygitrepo'
-  steps %Q{
+  steps %(
     Given a git repository named "#{repo_name}"
     And I cd to "#{repo_name}"
-  }
+  )
 end
 
 Given(/^I switch to git branch "([^"]*)"$/) do |branch_name|
-  steps %Q{
+  steps %(
     Given I successfully run `git checkout -b #{branch_name}`
-  }
+  )
 end
 
 Given(/^I switch to existing git branch "([^"]*)"$/) do |branch_name|
-  steps %Q{
+  steps %(
     Given I successfully run `git checkout #{branch_name}`
-  }
+  )
 end
 
 Given(/^I clone "(.*?)" to "(.*?)"$/) do |r1, r2|
-  steps %Q{
+  steps %(
     Given I successfully run `git clone #{r1}/.git #{r2}`
-  }
+  )
 end
 
 Given(/^I am in a complex working tree status matching scm_breeze tests$/) do
-  steps %Q{
+  steps %(
     Given I am in a git repository
     And an empty file named "deleted_file"
     And I successfully run `git add deleted_file`
@@ -54,7 +54,7 @@ Given(/^I am in a complex working tree status matching scm_breeze tests$/) do
       changed contents lolol
       """
     And I remove the file "deleted_file"
-  }
+  )
 end
 
 # Create a filesystem mock of the git repo, and copy it in.


### PR DESCRIPTION
When rebasing a branch and stopping to resolve a conflict, or when
looking at a particular commit, git will be in a detached head state
with `git status -bz` returning something along the lines of

` ## HEAD (no branch)UU file_with_conflicts.txt`

This fixes the function that parses this output internally for
scmpuff_status to not bail out loudly, but rather pass the `HEAD (no
branch)` state up.

Fixes https://github.com/mroth/scmpuff/issues/18