### PR TITLE
test environment: update aruba/cucumber deps to latest stable

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'aruba',    '~> 0.6.2'
-  gem 'cucumber', '~> 1.3.19'
+  gem 'aruba',    '~> 0.14.2'
+  gem 'cucumber', '~> 2.4.0'
 end

--- a/features/command_expand.feature
+++ b/features/command_expand.feature
@@ -67,13 +67,13 @@ Feature: command expansion at command line
         And the output should match /git\tcommit\t-m\tfoo\\;\\ bar/
 
   Scenario: Allow user to specify --relative paths
-    Given a directory named "foo"
-      And a directory named "foo/bar"
-      And an empty file named "xxx.jpg"
-      And I cd to "foo/bar"
-    Given I override environment variable "e1" to the absolute path of "xxx.jpg"
-    When I successfully run `scmpuff expand 1`
-    Then the stdout from "scmpuff expand 1" should contain the absolute path of "xxx.jpg"
+    Given a directory named "foo/bar"
+    And an empty file named "xxx.jpg"
+    And I override environment variable "e1" to the absolute path of "xxx.jpg"
+
+    When I cd to "foo/bar"
+    And I successfully run `scmpuff expand 1`
+    Then the stdout from "scmpuff expand 1" should contain the absolute path of "../../xxx.jpg"
     When I successfully run `scmpuff expand -r -- 1`
     Then the stdout from "scmpuff expand -r -- 1" should contain "../../xxx.jpg"
 

--- a/features/command_expand.feature
+++ b/features/command_expand.feature
@@ -41,7 +41,7 @@ Feature: command expansion at command line
     When I successfully run `scmpuff expand -- git xxx "foo bar" 1`
     Then the output should match /git\txxx\tfoo\\ bar\ta.txt/
 
-  Scenario Outline: Verify filenames with stupid characters are properly escaped
+  Scenario Outline: Verify filenames with silly characters are properly escaped
     Given I override the environment variables to:
       | variable | value      |
       | e1       | <filename> |
@@ -49,11 +49,12 @@ Feature: command expansion at command line
     Then the output should contain exactly "<escaped>"
     Examples:
       | filename       | escaped          |
-      | so(dumb).jpg   | so\(dumb\).jpg   |
+      | so(blah).jpg   | so\(blah\).jpg   |
       | hi mom.txt     | hi\ mom.txt      |
-      | "x.txt         | \"x.txt          |
       | wt;af.gif      | wt\;af.gif       |
       | foo\|bar       | foo\\\|bar       |
+  # TODO: quotation marks now trip up the regex rules in Aruba, so "x.txt is no longer tested,
+  # ...but it can probably be moved to a unit test intstead?
 
   Scenario: Semicolons in commit messages
     Given a git repository named "whatever"

--- a/features/command_expand.feature
+++ b/features/command_expand.feature
@@ -72,7 +72,7 @@ Feature: command expansion at command line
       And I cd to "foo/bar"
     Given I override environment variable "e1" to the absolute path of "xxx.jpg"
     When I successfully run `scmpuff expand 1`
-    Then the stdout from "scmpuff expand 1" should contain "/tmp/aruba/xxx.jpg"
+    Then the stdout from "scmpuff expand 1" should contain the absolute path of "xxx.jpg"
     When I successfully run `scmpuff expand -r -- 1`
     Then the stdout from "scmpuff expand -r -- 1" should contain "../../xxx.jpg"
 

--- a/features/command_status.feature
+++ b/features/command_status.feature
@@ -3,17 +3,16 @@ Feature: status command
   Background:
     Given a mocked home directory
 
-  @outside-repo
   Scenario: Appropriate error status when not in a git repo
     We can make this pretty, but we also want to be sure to use the same exit
     code as the normal 'git' command line client for consistency.
 
     When I run `scmpuff status`
-    Then the exit status should be 128
-    And the output should contain:
+    Then the output should contain:
       """
       Not a git repository (or any of the parent directories)
       """
+    And the exit status should be 128
 
   Scenario: Banner shows no changes when in an unchanged git repo
     Given I am in a git repository
@@ -257,7 +256,7 @@ Feature: status command
       """
     And I successfully run `git add file_with_conflict`
     And I successfully run `git commit -m "Original content"`
-    
+
     When I switch to git branch "foobar"
     And I append to "file_with_conflict" with "a change from foobar"
     And I successfully run `git add file_with_conflict`

--- a/features/command_status.feature
+++ b/features/command_status.feature
@@ -143,10 +143,7 @@ Feature: status command
       renamed:  [1] a.txt -> b.txt
       """
     When I successfully run `scmpuff status -f --display=false`
-    Then the stdout from "scmpuff status -f --display=false" should contain:
-      """
-      /tmp/aruba/mygitrepo/b.txt\n
-      """
+    Then the stdout from "scmpuff status -f --display=false" should contain the absolute path of "b.txt"
 
     Given I cd to "foo"
     When I successfully run `scmpuff status`
@@ -155,10 +152,7 @@ Feature: status command
       renamed:  [1] ../a.txt -> ../b.txt
       """
     When I successfully run `scmpuff status -f --display=false`
-    Then the stdout from "scmpuff status -f --display=false" should contain:
-      """
-      /tmp/aruba/mygitrepo/b.txt\n
-      """
+    Then the stdout from "scmpuff status -f --display=false" should contain the absolute path of "../b.txt"
 
 
   @recent-git-only

--- a/features/shell_functions.feature
+++ b/features/shell_functions.feature
@@ -6,7 +6,6 @@ Feature: scmpuff_status function
   Background:
     Given a mocked home directory
 
-  @outside-repo
   Scenario Outline: Handle error conditions from wrapped binary command
     It is possible for the underlying `scmpuff status` command wrapped by our
     shell function to produce errors, for example, when not in a git repository.

--- a/features/shell_wrappers.feature
+++ b/features/shell_wrappers.feature
@@ -55,14 +55,28 @@ Feature: optional wrapping of normal git cmds in the shell
     case surprisingly), and also it expands using --relative.
 
     Given I am in a git repository
-      And an empty file named "file with spaces.txt"
-    And I successfully run `git add "file with spaces.txt"`
-    When I run `<shell>` interactively
+    Given an empty file named "file with spaces.txt"
+    ###AAA
+    Given I successfully run `git add "file with spaces.txt"`
+
+    ###BBB
+    Given I run `<shell>` interactively
       And I type `eval "$(scmpuff init -ws)"`
       And I type "scmpuff_status"
       And I type "git reset 1"
+      And I type "echo 'DEBUG: PHASE BBB'"
       And I type "exit"
     Then the exit status should be 0
+    ### ^^^ this is checking exit status of AAA, not BBB!
+
+    # Then the output should contain "BBB"
+    ### ^^^ this command however, would force aruba to wait until BBB completes (super hacky option #1)
+
+    # Then I stop the command started last
+    ### ^^^ (hacky option #2) also seems to ensure BBB completes, but throws a deprecation error
+
+    ###CCC
+    ### currently, this phase is failing, because it is taking place *BEFORE* BBB completes
     When I run `scmpuff status`
     Then the stdout from "scmpuff status" should contain:
       """

--- a/features/step_definitions/scmpuff_steps.rb
+++ b/features/step_definitions/scmpuff_steps.rb
@@ -94,9 +94,18 @@ Given(/^I override the environment variables to:/) do |table|
 end
 
 Given(/^I override environment variable "(.*?)" to the absolute path of "(.*?)"$/) do |e, f|
-  filepath = File.expand_path File.join("tmp/aruba", f)
+  filepath = expand_path(f)
   set_environment_variable(e, filepath)
 end
+
+#
+# Handle unknown absolute paths in output
+#
+Then(/^the stdout from "([^"]*)" should contain the absolute path of "([^"]*)"$/) do |cmd, f|
+  filepath = expand_path(f)
+  step %Q(the stdout from "#{cmd}" should contain "#{filepath}")
+end
+
 
 #
 # Backtick version for "when I type" step to enable passing quotation marks

--- a/features/step_definitions/scmpuff_steps.rb
+++ b/features/step_definitions/scmpuff_steps.rb
@@ -68,9 +68,11 @@ Given(/^I am in the mocked git repository with commited subdirectory and file$/)
     Dir.chdir MOCK do
       FileUtils.mkdir "foo"
       FileUtils.touch "foo/placeholder.txt"
-      system("git init --quiet")
-      system("git add .")
-      system("git commit -m.")
+      system "git init --quiet"
+      system "git config --local user.name 'scmpuff mocker'"
+      system "git config --local user.email mocked@scmpuff.github.io"
+      system "git add ."
+      system "git commit -m."
     end
   end
   FileUtils.cp_r MOCK, expand_path(".")

--- a/features/step_definitions/scmpuff_steps.rb
+++ b/features/step_definitions/scmpuff_steps.rb
@@ -62,7 +62,7 @@ end
 # want to rerun the same git init every iteration, rather we just copy a fresh
 # copy of the mocked directory!
 Given(/^I am in the mocked git repository with commited subdirectory and file$/) do
-  MOCK ||= File.join(current_dir, "..", "mock", "gitsubdir") #needs to be outside of aruba clobber dir
+  MOCK ||= File.join(expand_path(".."), "mock", "gitsubdir") #needs to be outside of aruba clobber dir
   unless File.directory? MOCK
     FileUtils.mkdir_p MOCK
     Dir.chdir MOCK do
@@ -73,13 +73,13 @@ Given(/^I am in the mocked git repository with commited subdirectory and file$/)
       system("git commit -m.")
     end
   end
-  FileUtils.cp_r MOCK, current_dir
+  FileUtils.cp_r MOCK, expand_path(".")
   cd "gitsubdir"
 end
 
 Given(/^the scmpuff environment variables have been cleared$/) do
   (1..50).each do |n|
-    set_env("e#{n}", nil)
+    delete_environment_variable "e#{n}"
   end
 end
 
@@ -89,13 +89,13 @@ Given(/^I override the environment variables to:/) do |table|
   table.hashes.each do |row|
     variable = row['variable'].to_s
     value = row['value'].to_s
-    set_env(variable, value)
+    set_environment_variable(variable, value)
   end
 end
 
 Given(/^I override environment variable "(.*?)" to the absolute path of "(.*?)"$/) do |e, f|
   filepath = File.expand_path File.join("tmp/aruba", f)
-  set_env(e, filepath)
+  set_environment_variable(e, filepath)
 end
 
 #

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -3,7 +3,21 @@ Aruba.configure do |config|
   # default is ".", but...
   # we want to move this OUTSIDE of the project directory though, since aruba
   # isolation is insufficient otherwise for git not to see the parent repo.
-  config.root_directory = Dir.tmpdir
+  if (RUBY_PLATFORM =~ /darwin/)
+    # on macOS, /tmp and /var/folders are both actually symlinked into /private,
+    # which causes some reliability issues because Golang's os.Getwd does not
+    # consistently return a path, and it seems to like to return /private/tmp
+    # etc, whereas most ways the user might select the TMPDIR omit it, which
+    # makes our test matching more difficult.
+    #
+    # related, see also https://github.com/mroth/scmpuff/issues/11
+    #
+    # To get around this in tests, for now we just manually specify /private/tmp
+    # on macOS, since current versions of macOS/Golang seem to agree on.
+    config.root_directory = '/private/tmp'
+  else
+    config.root_directory = Dir.tmpdir
+  end
 
   # the working directory inside the root directory note that our hacky trick to
   # speed up mocks walks up one level from here and makes a sibling directory

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -3,9 +3,7 @@ Aruba.configure do |config|
   # default is ".", but...
   # we want to move this OUTSIDE of the project directory though, since aruba
   # isolation is insufficient otherwise for git not to see the parent repo.
-  #
-  # TODO: make this OS sensitive
-  config.root_directory = '/tmp/'
+  config.root_directory = Dir.tmpdir
 
   # the working directory inside the root directory note that our hacky trick to
   # speed up mocks walks up one level from here and makes a sibling directory

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,0 +1,17 @@
+Aruba.configure do |config|
+  # root directory for aruba tests
+  # default is ".", but...
+  # we want to move this OUTSIDE of the project directory though, since aruba
+  # isolation is insufficient otherwise for git not to see the parent repo.
+  #
+  # TODO: make this OS sensitive
+  config.root_directory = '/tmp/'
+
+  # the working directory inside the root directory note that our hacky trick to
+  # speed up mocks walks up one level from here and makes a sibling directory
+  # (see "mocked git repository with commited subdirectory and file" in
+  # scmpuff_steps.rb for details)
+  #
+  # default is "tmp/aruba", but that is confusing when nested inside '/tmp'
+  config.working_directory = 'aruba/workdir'
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,9 +8,3 @@ Before do
   set_environment_variable 'GIT_AUTHOR_EMAIL',    author_email
   set_environment_variable 'GIT_COMMITTER_EMAIL', author_email
 end
-
-# since tmp/aruba is nested within the git repo of this program, we need to
-# be somewhere else to test behavior of the binary when outside the git repo.
-Before('@outside-repo') do
-  @dirs = ["/tmp/aruba/scmpuff"]
-end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,10 +3,10 @@ require 'aruba/cucumber'
 Before do
   author_name  = "SCM Puff"
   author_email = "scmpuff@test.local"
-  set_env 'GIT_AUTHOR_NAME',     author_name
-  set_env 'GIT_COMMITTER_NAME',  author_name
-  set_env 'GIT_AUTHOR_EMAIL',    author_email
-  set_env 'GIT_COMMITTER_EMAIL', author_email
+  set_environment_variable 'GIT_AUTHOR_NAME',     author_name
+  set_environment_variable 'GIT_COMMITTER_NAME',  author_name
+  set_environment_variable 'GIT_AUTHOR_EMAIL',    author_email
+  set_environment_variable 'GIT_COMMITTER_EMAIL', author_email
 end
 
 # since tmp/aruba is nested within the git repo of this program, we need to


### PR DESCRIPTION
while Aruba is still not shipping 1.0 (see #15), making me a bit nervous about the state of the project, it's been long enough that I want to try to get the tests running on latest stable anyhow, so we're in a cleaner state to be prepared, and to work towards starting to get CI working in Windows environments as well.