### PR TITLE
scmpuff expand should escape '*'

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
   - bash --version
   - git --version
   # TODO: install ruby dependencies for integration testing
-  - gem install bundler --quiet --no-ri --no-rdoc
+  - gem install bundler --quiet --no-document
   - bundle install --jobs 4 --retry 3 --path vendor/bundle
   - bundle exec cucumber --version
 

--- a/commands/expand/expand.go
+++ b/commands/expand/expand.go
@@ -50,7 +50,7 @@ Takes a list of digits (1 4 5) or numeric ranges (1-5) or even both.`,
 
 var expandArgDigitMatcher = regexp.MustCompile("^[0-9]{0,4}$")
 var expandArgRangeMatcher = regexp.MustCompile("^([0-9]+)-([0-9]+)$")
-var shellEscaper = regexp.MustCompile("([\\^()\\[\\]<>' \";\\|])")
+var shellEscaper = regexp.MustCompile("([\\^()\\[\\]<>' \";\\|*])")
 
 // Process expands args and performs all substitution, etc.
 //

--- a/features/command_expand.feature
+++ b/features/command_expand.feature
@@ -41,6 +41,10 @@ Feature: command expansion at command line
     When I successfully run `scmpuff expand -- git xxx "foo bar" 1`
     Then the output should match /git\txxx\tfoo\\ bar\ta.txt/
 
+  Scenario: Make sure args with globs get escaped on way back
+    When I successfully run `scmpuff expand -- git xxx --exclude='refs/wip/*' 1`
+    Then the output should contain "git	xxx	--exclude=refs/wip/\*	a.txt"
+
   Scenario Outline: Verify filenames with stupid characters are properly escaped
     Given I override the environment variables to:
       | variable | value      |


### PR DESCRIPTION
if a literal '*' is passed to `scmpuff expand`, it echos it back in the output without any escaping:

```
$ scmpuff expand -- git log --exclude='refs/wip/*'
git	log	--exclude=refs/wip/*
```

Shouldn't this be escaped?  How about this PR?