### PR TITLE
integration tests via aruba 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 language: go
 go:
-  - 1.14
+  - 1.17
 
 env:
   - GO111MODULE=on
@@ -22,7 +22,7 @@ install:
 script:
   - go test ./...
   - script/build
-  - bundle exec cucumber -s --tags=~@wip
+  - bundle exec cucumber -s --tags="not @wip"
 
 before_cache:
   - bundle clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
   - go test ./...
   - script/build
-  - bundle exec cucumber -s --tags="not @wip"
+  - bundle exec cucumber -s --tags="not @wip" --publish
 
 before_cache:
   - bundle clean

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'aruba',    '~> 0.6.2'
-  gem 'cucumber', '~> 1.3.19'
+  gem 'aruba',    '~> 2.0.0'
 end

--- a/features/shell_functions.feature
+++ b/features/shell_functions.feature
@@ -51,6 +51,7 @@ Feature: scmpuff_status function
       And I type "scmpuff_status"
       And I type `echo -e "e1:$e1\ne2:$e2\ne3:$e3\ne4:$e4\ne5:$e5\n"`
       And I type "exit"
+    And I stop the command "<shell>"
     Then the output should match /^e1:.*new_file$/
       And the output should match /^e2:.*deleted_file$/
       And the output should match /^e3:.*new_file$/
@@ -71,6 +72,7 @@ Feature: scmpuff_status function
       And I type "scmpuff_status"
       And I type `echo -e "e1:$e1\ne2:$e2\ne3:$e3\ne4:$e4\n"`
       And I type "exit"
+    And I stop the command "<shell>"
     Then the output should match /^e1:.*aa bb$/
       And the output should match /^e2:.*bb\|cc$/
       And the output should match /^e3:.*cc\*dd$/

--- a/features/shell_wrappers.feature
+++ b/features/shell_wrappers.feature
@@ -62,6 +62,7 @@ Feature: optional wrapping of normal git cmds in the shell
       And I type "scmpuff_status"
       And I type "git reset 1"
       And I type "exit"
+    And I stop the command "<shell>"
     Then the exit status should be 0
     When I run `scmpuff status`
     Then the stdout from "scmpuff status" should contain:
@@ -87,6 +88,7 @@ Feature: optional wrapping of normal git cmds in the shell
       And I type "scmpuff_status"
       And I type "git restore --staged 1"
       And I type "exit"
+    And I stop the command "<shell>"
     Then the exit status should be 0
     When I run `scmpuff status`
     Then the stdout from "scmpuff status" should contain:

--- a/features/step_definitions/scmpuff_steps.rb
+++ b/features/step_definitions/scmpuff_steps.rb
@@ -62,7 +62,7 @@ end
 # want to rerun the same git init every iteration, rather we just copy a fresh
 # copy of the mocked directory!
 Given(/^I am in the mocked git repository with commited subdirectory and file$/) do
-  MOCK ||= File.join(current_dir, "..", "mock", "gitsubdir") #needs to be outside of aruba clobber dir
+  MOCK ||= File.join(current_directory, "..", "mock", "gitsubdir") #needs to be outside of aruba clobber dir
   unless File.directory? MOCK
     FileUtils.mkdir_p MOCK
     Dir.chdir MOCK do
@@ -73,13 +73,13 @@ Given(/^I am in the mocked git repository with commited subdirectory and file$/)
       system("git commit -m.")
     end
   end
-  FileUtils.cp_r MOCK, current_dir
+  FileUtils.cp_r MOCK, current_directory
   cd "gitsubdir"
 end
 
 Given(/^the scmpuff environment variables have been cleared$/) do
   (1..50).each do |n|
-    set_env("e#{n}", nil)
+    set_environment_variable("e#{n}", nil)
   end
 end
 
@@ -89,13 +89,13 @@ Given(/^I override the environment variables to:/) do |table|
   table.hashes.each do |row|
     variable = row['variable'].to_s
     value = row['value'].to_s
-    set_env(variable, value)
+    set_environment_variable(variable, value)
   end
 end
 
 Given(/^I override environment variable "(.*?)" to the absolute path of "(.*?)"$/) do |e, f|
   filepath = File.expand_path File.join("tmp/aruba", f)
-  set_env(e, filepath)
+  set_environment_variable(e, filepath)
 end
 
 #

--- a/features/step_definitions/scmpuff_steps.rb
+++ b/features/step_definitions/scmpuff_steps.rb
@@ -62,7 +62,7 @@ end
 # want to rerun the same git init every iteration, rather we just copy a fresh
 # copy of the mocked directory!
 Given(/^I am in the mocked git repository with commited subdirectory and file$/) do
-  MOCK ||= File.join(current_directory, "..", "mock", "gitsubdir") #needs to be outside of aruba clobber dir
+  MOCK ||= File.join(aruba.current_directory, "..", "mock", "gitsubdir") #needs to be outside of aruba clobber dir
   unless File.directory? MOCK
     FileUtils.mkdir_p MOCK
     Dir.chdir MOCK do
@@ -73,7 +73,7 @@ Given(/^I am in the mocked git repository with commited subdirectory and file$/)
       system("git commit -m.")
     end
   end
-  FileUtils.cp_r MOCK, current_directory
+  FileUtils.cp_r MOCK, aruba.current_directory
   cd "gitsubdir"
 end
 

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,0 +1,3 @@
+Aruba.configure do |config|
+  config.allow_absolute_paths = true
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,10 +3,10 @@ require 'aruba/cucumber'
 Before do
   author_name  = "SCM Puff"
   author_email = "scmpuff@test.local"
-  set_env 'GIT_AUTHOR_NAME',     author_name
-  set_env 'GIT_COMMITTER_NAME',  author_name
-  set_env 'GIT_AUTHOR_EMAIL',    author_email
-  set_env 'GIT_COMMITTER_EMAIL', author_email
+  set_environment_variable 'GIT_AUTHOR_NAME',     author_name
+  set_environment_variable 'GIT_COMMITTER_NAME',  author_name
+  set_environment_variable 'GIT_AUTHOR_EMAIL',    author_email
+  set_environment_variable 'GIT_COMMITTER_EMAIL', author_email
 end
 
 # since tmp/aruba is nested within the git repo of this program, we need to

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,5 +12,6 @@ end
 # since tmp/aruba is nested within the git repo of this program, we need to
 # be somewhere else to test behavior of the binary when outside the git repo.
 Before('@outside-repo') do
-  cd "/tmp/aruba/scmpuff"
+  tmpdir = Dir.mktmpdir("aruba")
+  cd tmpdir
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,5 +12,5 @@ end
 # since tmp/aruba is nested within the git repo of this program, we need to
 # be somewhere else to test behavior of the binary when outside the git repo.
 Before('@outside-repo') do
-  @dirs = ["/tmp/aruba/scmpuff"]
+  cd "/tmp/aruba/scmpuff"
 end


### PR DESCRIPTION
I'd like to get rid of the ruby runtime requirement for integration testing altogether (I should probably finish writing my Go Aruba port someday), but in the meantime, let's see if we can get it working with the most recent version as a precursor to isolating it in a container.

closes #30.