### PR TITLE
don't force hub usage in git-wrapper if installed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## Development
+
+While the build process itself does not require it, development uses Ruby for
+integration testing because of the excellent Cucumber/Aruba package for testing
+CLI tools.
+
+Thus, to bootstrap, you will need to have Ruby and bundler installed on your
+system.  Do `bundle install` to get the dev environment going.
+
+Since we already have Ruby then for tests, we use a Rakefile instead of Makefile
+since it offers some niceties.  Do `rake -T` to see available tasks.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ shell integration is under 100 lines of shell script.
 system. It's written with cross-platform support in mind, so hopefully we'll
 have it functioning on Windows soon as well.
 
-**scmpuff** is fully compatible with the most-excellent [Hub][hub].
-
 [scmbreeze]: https://github.com/ndbroadbent/scm_breeze
-[hub]: https://github.com/github/hub
 
 ## Installation
 
@@ -87,8 +84,8 @@ e.g. `ga`, `gd`, `gco`.  Check your aliases to see what they are.
 
 ### How does it compare with SCM Breeze?
 
-The short version: it does less, but is faster and should be significantly more
-stable and reliable, especially across different platforms.
+The short version: it does less, but is faster and should be more stable and
+reliable, especially across different platforms.
 
 The long, detailed version:
 https://github.com/mroth/scmpuff/wiki/scmpuff-vs-SCM-Breeze
@@ -99,15 +96,12 @@ in your shell initialization.  Then, if you wish to remap them, simple modify
 your default aliases wherever you normally do, but add aliases mapped to the
 scmpuff shell functions, e.g. `alias gs='scmpuff_status'`.
 
+### I want to use scmpuff in conjunction with [hub][hub] or something else that I've aliased git to, how would I do so?
 
-## Development
+By default, scmpuff will attempt to utilize the absolute path of whatever `git`
+it finds in your system PATH, ignoring existing shell aliases.  If you want to
+use a different binary, set `$SCMPUFF_GIT_CMD` in your shell to the path, for
+example, `export SCMPUFF_GIT_CMD=/usr/local/bin/hub`.
 
-While the build process itself does not require it, development uses Ruby for
-integration testing because of the excellent Cucumber/Aruba package for testing
-CLI tools.
+[hub]: https://github.com/github/hub
 
-Thus, to bootstrap, you will need to have Ruby and bundler installed on your
-system.  Do `bundle install` to get the dev environment going.
-
-Since we already have Ruby then for tests, we use a Rakefile instead of Makefile
-since it offers some niceties.  Do `rake -T` to see available tasks.

--- a/commands/inits/data/git_wrapper.sh
+++ b/commands/inits/data/git_wrapper.sh
@@ -5,9 +5,6 @@ unset -f git > /dev/null 2>&1
 # Use the full path to git to avoid infinite loop with git function
 export SCMPUFF_GIT_CMD="$(\which git)"
 
-# Wrap git with the 'hub' github wrapper, if installed
-if type hub > /dev/null 2>&1; then export SCMPUFF_GIT_CMD="hub"; fi
-
 function git() {
   case $1 in
     commit|blame|log|rebase|merge)

--- a/commands/inits/data/git_wrapper.sh
+++ b/commands/inits/data/git_wrapper.sh
@@ -3,7 +3,8 @@ unalias git > /dev/null 2>&1
 unset -f git > /dev/null 2>&1
 
 # Use the full path to git to avoid infinite loop with git function
-export SCMPUFF_GIT_CMD="$(\which git)"
+SCMPUFF_GIT_CMD=${SCMPUFF_GIT_CMD:-"$(\which git)"}
+export SCMPUFF_GIT_CMD
 
 function git() {
   case $1 in

--- a/features/shell_functions.feature
+++ b/features/shell_functions.feature
@@ -116,7 +116,21 @@ Feature: scmpuff_status function
       | bash  |
       | zsh   |
 
-  Scenario Outline: SCMPUFF_GIT_CMD respects override via existing environment variables
+  Scenario Outline: SCMPUFF_GIT_CMD is set to absolute path of a git command, eliminating aliases
+    When I run `<shell>` interactively
+      And I type "alias git=/foo/bar"
+      And I type `eval "$(scmpuff init -s)"`
+      And I type "echo $SCMPUFF_GIT_CMD"
+      And I type "exit"
+    And I stop the command "<shell>"
+    Then the output should match %r<^/.+/git$>
+    # ^^ is absolute path to git: begins with a /, and ends with /git
+    Examples:
+      | shell |
+      | bash  |
+      | zsh   |
+
+  Scenario Outline: SCMPUFF_GIT_CMD respects existing environment variables
     When I run `<shell>` interactively
       And I type "export SCMPUFF_GIT_CMD=/foo/hub"
       And I type `eval "$(scmpuff init -s)"`

--- a/features/shell_functions.feature
+++ b/features/shell_functions.feature
@@ -102,3 +102,29 @@ Feature: scmpuff_status function
       | shell |
       | bash  |
       | zsh   |
+
+  Scenario Outline: default SCMPUFF_GIT_CMD is set to absolute path of a git command
+    When I run `<shell>` interactively
+      And I type `eval "$(scmpuff init -s)"`
+      And I type "echo $SCMPUFF_GIT_CMD"
+      And I type "exit"
+    And I stop the command "<shell>"
+    Then the output should match %r<^/.+/git$>
+    # ^^ is absolute path to git: begins with a /, and ends with /git
+    Examples:
+      | shell |
+      | bash  |
+      | zsh   |
+
+  Scenario Outline: SCMPUFF_GIT_CMD respects override via existing environment variables
+    When I run `<shell>` interactively
+      And I type "export SCMPUFF_GIT_CMD=/foo/hub"
+      And I type `eval "$(scmpuff init -s)"`
+      And I type "echo $SCMPUFF_GIT_CMD"
+      And I type "exit"
+    And I stop the command "<shell>"
+    Then the output should contain exactly "/foo/hub"
+    Examples:
+      | shell |
+      | bash  |
+      | zsh   |


### PR DESCRIPTION
[reserved for full PR description]

- [x] remove hub force aliasing
- [x] respect existing SCMPUFF_GIT_CMD if preset (either before or after scruff is inited)
- [x] add integration tests
- [x] update documentation
