### PR TITLE
Remove duplicated fish flag from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ have it functioning on Windows soon as well.
 
 [scmbreeze]: https://github.com/ndbroadbent/scm_breeze
 
+
 ## Installation
 
 [Download] the binary for your platform, and copy it to `/usr/local/bin` or
@@ -26,22 +27,25 @@ somewhere else in your  default `$PATH`.
 Alternately, if you use [homebrew], you can just: `brew install scmpuff`. :beer:
 
 [download]: https://github.com/mroth/scmpuff/releases/latest
-[homebrew]: http://brew.sh
+[homebrew]: https://brew.sh
+
 
 ## Setup
 
-Currently scmpuff supports bash and zsh for all functionality.
+Currently scmpuff supports bash, zsh and [fish] for all functionality.
 
 To initialize shell functions, add the following to your `~/.bash_profile` or
 `~/.zshrc` file:
 
     eval "$(scmpuff init -s)"
 
-or for Fish, add the following to your `~/.config/fish/config.fish` file:
+or for fish, add the following to your `~/.config/fish/config.fish` file:
 
-    scmpuff init -s --shell=fish | source
+    scmpuff init --shell=fish | source
 
 This will define the scmpuff shell functions as well as some handy shortcuts.
+
+[fish]: https://fishshell.com/
 
 
 ## Usage


### PR DESCRIPTION
To match usage in CLI, where `-s` and `--shell` have the same meaning:

```
> scmpuff init --help

Outputs the shell initialization script for scmpuff.

Initialize scmpuff by adding the following to your ~/.bash_profile or ~/.zshrc:

    eval "$(scmpuff init --shell=sh)"

For fish shell, add the following to ~/.config/fish/config.fish instead:

    scmpuff init --shell=fish | source

There are a number of flags to customize the shell integration.

Usage:
  scmpuff init [flags]

Flags:
  -a, --aliases                 Include short git aliases (default true)
  -h, --help                    help for init
  -s, --shell string[="fish"]   Output shell type: sh | bash | zsh | fish
  -w, --wrap                    Wrap standard git commands (default true)
```