### PR TITLE
status: Handle symbolic links correctly

### DIFF
--- a/features/command_status.feature
+++ b/features/command_status.feature
@@ -78,7 +78,6 @@ Feature: status command
       And the output should match /untracked: *\[4\] *untracked_file/
 
 
-  @wip
   Scenario: Status properly reports all file changes w/ symlink
     Given I am in a complex working tree status matching scm_breeze tests
     When I cd to ".."

--- a/features/command_status.feature
+++ b/features/command_status.feature
@@ -78,6 +78,18 @@ Feature: status command
       And the output should match /untracked: *\[4\] *untracked_file/
 
 
+  @wip
+  Scenario: Status properly reports all file changes w/ symlink
+    Given I am in a complex working tree status matching scm_breeze tests
+    When I cd to ".."
+      And I run `sh -c 'ln -s mygitrepo symlink && cd symlink && scmpuff status'`
+    Then the exit status should be 0
+      And the output should match / new file: *\[1\] *new_file/
+      And the output should match /  deleted: *\[2\] *deleted_file/
+      And the output should match / modified: *\[3\] *new_file/
+      And the output should match /untracked: *\[4\] *untracked_file/
+
+
   Scenario Outline: Handles file path magic properly for new & untracked files
     You would think this would be the same across file groups, but in fact the
     way `git status --porcelain` outputs these is different, so we need to test


### PR DESCRIPTION
A simplified version of #85 with test coverage. There are two commits:

1. The first commit adds a failing test with `@wip`. The test is failing because of #11.
2. The second commit fixes #11 and removes `@wip`, since the test is now passing.

Fixes #11
Closes #85