### PR TITLE
fix: add support for unstaged rename and copy status codes

### DIFF
--- a/docs/git-status-parsing.md
+++ b/docs/git-status-parsing.md
@@ -55,9 +55,9 @@ Porcelain v1 does not provide branch data in a structured format — it encodes 
 
 ## The ChangeType design
 
-`ChangeType` is the central abstraction that bridges parsing and rendering. It's a flat enum with 18 named variants that each capture a specific combination of *where* a change is (staged, unstaged, unmerged, or untracked) and *what kind* of change it is (modified, new, deleted, renamed, etc). Each variant has three derived properties — `Message()`, `State()`, and `StatusGroup()` — backed by a single metadata lookup table, so adding a new variant is a one-line map entry. The renderer uses `StatusGroup()` for section grouping and section-level colors, and `State()` for per-item label colors (so staged and unstaged "modified" share the same label color even though they appear in different sections).
+`ChangeType` is the central abstraction that bridges parsing and rendering. It's a flat enum with 20 named variants that each capture a specific combination of *where* a change is (staged, unstaged, unmerged, or untracked) and *what kind* of change it is (modified, new, deleted, renamed, etc). Each variant has three derived properties — `Message()`, `State()`, and `StatusGroup()` — backed by a single metadata lookup table, so adding a new variant is a one-line map entry. The renderer uses `StatusGroup()` for section grouping and section-level colors, and `State()` for per-item label colors (so staged and unstaged "modified" share the same label color even though they appear in different sections).
 
-This table is the canonical reference for the 18 variants currently handled. It is **known to be incomplete** — git has introduced new XY code combinations over the years that scmpuff does not yet recognize. The variant definitions, metadata, and XY decoding logic are spread across multiple source files; this table consolidates them in one place.
+This table is the canonical reference for the 20 variants currently handled. The variant definitions, metadata, and XY decoding logic are spread across multiple source files; this table consolidates them in one place.
 
 | ChangeType                   | Message()         | State()            | StatusGroup() |
 |------------------------------|-------------------|--------------------|---------------|
@@ -78,6 +78,8 @@ This table is the canonical reference for the 18 variants currently handled. It 
 | `ChangeUnstagedDeleted`      | `deleted`         | `DeletedState`     | `Unstaged`    |
 | `ChangeUnstagedType`         | `typechange`      | `TypeChangedState` | `Unstaged`    |
 | `ChangeUnstagedNewFile`      | `new file`        | `NewState`         | `Unstaged`    |
+| `ChangeUnstagedRenamed`      | `renamed`         | `RenamedState`     | `Unstaged`    |
+| `ChangeUnstagedCopied`       | `copied`          | `CopiedState`      | `Unstaged`    |
 | `ChangeUntracked`            | `untracked`       | `UntrackedState`   | `Untracked`   |
 
 ## Test data and debugging

--- a/internal/cmd/status/render_test.go
+++ b/internal/cmd/status/render_test.go
@@ -172,6 +172,20 @@ func TestRenderer_Display(t *testing.T) {
 			cwd:  "/path/to/repo",
 		},
 		{
+			name: "unstaged_rename_copy",
+			info: gitstatus.StatusInfo{
+				Branch: gitstatus.BranchInfo{Name: "main", CommitsAhead: 0, CommitsBehind: 0},
+				Items: []gitstatus.StatusItem{
+					{ChangeType: gitstatus.ChangeUnstagedRenamed, Path: "new_name.txt", OrigPath: "old_name.txt"},
+					{ChangeType: gitstatus.ChangeUnstagedCopied, Path: "copy.txt", OrigPath: "original.txt"},
+					{ChangeType: gitstatus.ChangeStagedModified, Path: "also_renamed.txt"},
+					{ChangeType: gitstatus.ChangeUnstagedRenamed, Path: "also_renamed.txt", OrigPath: "was_this.txt"},
+				},
+			},
+			root: "/path/to/repo",
+			cwd:  "/path/to/repo",
+		},
+		{
 			name: "type_changes",
 			info: gitstatus.StatusInfo{
 				Branch: gitstatus.BranchInfo{Name: "type-change", CommitsAhead: 1, CommitsBehind: 0},

--- a/internal/cmd/status/testdata/statuslist-unstaged_rename_copy.display.ansi.golden
+++ b/internal/cmd/status/testdata/statuslist-unstaged_rename_copy.display.ansi.golden
@@ -1,0 +1,12 @@
+[2;37m#[0m On branch: [1mmain  [2;37m|  [[0m*[2;37m][0m => $e*
+[2;37m#[0m
+[1;33m➤[0m Changes to be committed
+[0;33m#[0m
+[0;33m#[0m     [0;32m  modified: [2;37m [[0m1[2;37m] [0;33malso_renamed.txt[0m
+[0;33m#[0m
+[1;32m➤[0m Changes not staged for commit
+[0;32m#[0m
+[0;32m#[0m     [0;34m   renamed: [2;37m [[0m2[2;37m] [0;32mold_name.txt -> new_name.txt[0m
+[0;32m#[0m     [0;33m    copied: [2;37m [[0m3[2;37m] [0;32moriginal.txt -> copy.txt[0m
+[0;32m#[0m     [0;34m   renamed: [2;37m [[0m4[2;37m] [0;32mwas_this.txt -> also_renamed.txt[0m
+[0;32m#[0m

--- a/internal/cmd/status/testdata/statuslist-unstaged_rename_copy.parsedata.txt.golden
+++ b/internal/cmd/status/testdata/statuslist-unstaged_rename_copy.parsedata.txt.golden
@@ -1,0 +1,1 @@
+/path/to/repo/also_renamed.txt	/path/to/repo/new_name.txt	/path/to/repo/copy.txt	/path/to/repo/also_renamed.txt

--- a/internal/gitstatus/gitstatus.go
+++ b/internal/gitstatus/gitstatus.go
@@ -123,6 +123,8 @@ const (
 	ChangeUnstagedDeleted
 	ChangeUnstagedType
 	ChangeUnstagedNewFile
+	ChangeUnstagedRenamed
+	ChangeUnstagedCopied
 
 	// Untracked changes
 	ChangeUntracked
@@ -147,6 +149,8 @@ var changeTypeData = map[ChangeType]changeTypeMetadata{
 	ChangeUnstagedDeleted:      {msg: "deleted", state: DeletedState, group: Unstaged},
 	ChangeUnstagedType:         {msg: "typechange", state: TypeChangedState, group: Unstaged},
 	ChangeUnstagedNewFile:      {msg: "new file", state: NewState, group: Unstaged},
+	ChangeUnstagedRenamed:      {msg: "renamed", state: RenamedState, group: Unstaged},
+	ChangeUnstagedCopied:       {msg: "copied", state: CopiedState, group: Unstaged},
 	ChangeUntracked:            {msg: "untracked", state: UntrackedState, group: Untracked},
 }
 

--- a/internal/gitstatus/porcelainv1/process.go
+++ b/internal/gitstatus/porcelainv1/process.go
@@ -245,6 +245,10 @@ func decodeSecondaryChangeCode(x, y byte) (gitstatus.ChangeType, bool) {
 	// Don't show added 'y' during a merge conflict.
 	case y == 'A' && x != 'A' && x != 'U': //[!A!U]A (intent-to-add, via git add -N)
 		return gitstatus.ChangeUnstagedNewFile, true
+	case y == 'R': //.R
+		return gitstatus.ChangeUnstagedRenamed, true
+	case y == 'C': //.C
+		return gitstatus.ChangeUnstagedCopied, true
 	}
 
 	return -1, false

--- a/internal/gitstatus/porcelainv1/process_test.go
+++ b/internal/gitstatus/porcelainv1/process_test.go
@@ -72,10 +72,46 @@ func Test_extractChangeTypes(t *testing.T) {
 			},
 		},
 		{
+			[]byte(" R"), //[]byte(" R renamed_in_worktree"),
+			[]gitstatus.ChangeType{
+				gitstatus.ChangeUnstagedRenamed,
+			},
+		},
+		{
+			[]byte(" C"), //[]byte(" C copied_in_worktree"),
+			[]gitstatus.ChangeType{
+				gitstatus.ChangeUnstagedCopied,
+			},
+		},
+		{
 			[]byte("AM"), //[]byte("AM added_then_modified_file"),
 			[]gitstatus.ChangeType{
 				gitstatus.ChangeStagedNewFile,
 				gitstatus.ChangeUnstagedModified,
+			},
+		},
+		{
+			// Compound code: staged modified + unstaged renamed
+			[]byte("MR"),
+			[]gitstatus.ChangeType{
+				gitstatus.ChangeStagedModified,
+				gitstatus.ChangeUnstagedRenamed,
+			},
+		},
+		{
+			// Compound code: staged copied + unstaged renamed
+			[]byte("CR"),
+			[]gitstatus.ChangeType{
+				gitstatus.ChangeStagedCopied,
+				gitstatus.ChangeUnstagedRenamed,
+			},
+		},
+		{
+			// Compound code: staged modified + unstaged copied
+			[]byte("MC"),
+			[]gitstatus.ChangeType{
+				gitstatus.ChangeStagedModified,
+				gitstatus.ChangeUnstagedCopied,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Add `ChangeUnstagedRenamed` (Y=`R`) and `ChangeUnstagedCopied` (Y=`C`) — the last two currently known unhandled XY codes from the git status short format
- ` R` and ` C` previously caused a fatal parse error; compound codes like `MR` or `CR` silently dropped the unstaged rename/copy
- Follows the same pattern established in #141 for intent-to-add (`Y='A'`)