### PR TITLE
internal/cmd: git_wrapper: add `git stash push` to wrapped subcommands

### DIFF
--- a/internal/cmd/inits/data/git_wrapper.fish
+++ b/internal/cmd/inits/data/git_wrapper.fish
@@ -16,6 +16,13 @@ function git
         scmpuff exec -- "$SCMPUFF_GIT_CMD" $argv
     case checkout diff rm reset restore
         scmpuff exec --relative -- "$SCMPUFF_GIT_CMD" $argv
+    case stash
+        switch $argv[2]
+        case push
+            scmpuff exec --relative -- "$SCMPUFF_GIT_CMD" $argv
+        case '*'
+            eval command "$SCMPUFF_GIT_CMD" (string escape -- $argv)
+        end
     case add
         scmpuff exec -- "$SCMPUFF_GIT_CMD" $argv
         scmpuff_status

--- a/internal/cmd/inits/data/git_wrapper.sh
+++ b/internal/cmd/inits/data/git_wrapper.sh
@@ -13,6 +13,14 @@ function git() {
       scmpuff exec -- "$SCMPUFF_GIT_CMD" "$@";;
     checkout|diff|rm|reset|restore)
       scmpuff exec --relative -- "$SCMPUFF_GIT_CMD" "$@";;
+    stash)
+      case ${2-:} in
+        push)
+          scmpuff exec --relative -- "$SCMPUFF_GIT_CMD" "$@";;
+        *)
+          "$SCMPUFF_GIT_CMD" "$@";;
+      esac
+      ;;
     add)
       scmpuff exec -- "$SCMPUFF_GIT_CMD" "$@"
       scmpuff_status;;

--- a/internal/cmd/testdata/script/command-shell-wrapper-stash-passthrough.txtar
+++ b/internal/cmd/testdata/script/command-shell-wrapper-stash-passthrough.txtar
@@ -1,0 +1,53 @@
+# Scenario: Wrapped git stash passes non-`push` subcommands straight through
+# Purpose: Verify bare `git stash` and `git stash pop` are forwarded unchanged
+#          (no numeric expansion) and do not error. Bare `git stash` in
+#          particular exercises the empty second-argument code path.
+# Verbose notes: stash requires an initial commit (HEAD); uses per-shell repo
+#                copies to avoid state mutation overlap.
+
+exec git init repo_base
+cd repo_base
+exec git add foo.bar
+exec git commit -m 'initial commit'
+cp ../foo.bar.modified foo.bar
+cd ..
+
+# Bash
+[exec:bash] exec cp -R repo_base repo_bash
+[exec:bash] cd repo_bash
+[exec:bash] exec bash -c 'eval "$(scmpuff init -s)"; scmpuff_status >/dev/null; git stash'
+[exec:bash] exec git status --porcelain
+[exec:bash] ! stdout .
+[exec:bash] exec bash -c 'eval "$(scmpuff init -s)"; git stash pop'
+[exec:bash] exec git status --porcelain
+[exec:bash] cmp stdout ../expected-porcelain.txt
+[exec:bash] cd ..
+
+# Zsh
+[exec:zsh] exec cp -R repo_base repo_zsh
+[exec:zsh] cd repo_zsh
+[exec:zsh] exec zsh -c 'eval "$(scmpuff init -s)"; scmpuff_status >/dev/null; git stash'
+[exec:zsh] exec git status --porcelain
+[exec:zsh] ! stdout .
+[exec:zsh] exec zsh -c 'eval "$(scmpuff init -s)"; git stash pop'
+[exec:zsh] exec git status --porcelain
+[exec:zsh] cmp stdout ../expected-porcelain.txt
+[exec:zsh] cd ..
+
+# Fish
+[exec:fish] exec cp -R repo_base repo_fish
+[exec:fish] cd repo_fish
+[exec:fish] exec fish -c 'scmpuff init --shell=fish | source; scmpuff_status >/dev/null; git stash'
+[exec:fish] exec git status --porcelain
+[exec:fish] ! stdout .
+[exec:fish] exec fish -c 'scmpuff init --shell=fish | source; git stash pop'
+[exec:fish] exec git status --porcelain
+[exec:fish] cmp stdout ../expected-porcelain.txt
+[exec:fish] cd ..
+
+-- repo_base/foo.bar --
+ab
+-- foo.bar.modified --
+abcd
+-- expected-porcelain.txt --
+ M foo.bar

--- a/internal/cmd/testdata/script/command-shell-wrapper-stash-push-by-number.txtar
+++ b/internal/cmd/testdata/script/command-shell-wrapper-stash-push-by-number.txtar
@@ -1,0 +1,48 @@
+# Scenario: Wrapped `git stash push <n>` stashes the selected file by number
+# Purpose: Verify wrapped `stash push` expands a numeric arg to the right path,
+#          stashing only that file and leaving the others modified.
+# Verbose notes: stash requires an initial commit (HEAD); uses per-shell repo
+#                copies to avoid state mutation overlap.
+
+exec git init repo_base
+cd repo_base
+exec git add bar.foo foo.bar
+exec git commit -m 'initial commit'
+cp ../bar.foo.modified bar.foo
+cp ../foo.bar.modified foo.bar
+cd ..
+
+# Bash
+[exec:bash] exec cp -R repo_base repo_bash
+[exec:bash] cd repo_bash
+[exec:bash] exec bash -c 'eval "$(scmpuff init -s)"; scmpuff_status >/dev/null; git stash push 1'
+[exec:bash] exec git status --porcelain
+[exec:bash] cmp stdout ../expected-porcelain.txt
+[exec:bash] cd ..
+
+# Zsh
+[exec:zsh] exec cp -R repo_base repo_zsh
+[exec:zsh] cd repo_zsh
+[exec:zsh] exec zsh -c 'eval "$(scmpuff init -s)"; scmpuff_status >/dev/null; git stash push 1'
+[exec:zsh] exec git status --porcelain
+[exec:zsh] cmp stdout ../expected-porcelain.txt
+[exec:zsh] cd ..
+
+# Fish
+[exec:fish] exec cp -R repo_base repo_fish
+[exec:fish] cd repo_fish
+[exec:fish] exec fish -c 'scmpuff init --shell=fish | source; scmpuff_status >/dev/null; git stash push 1'
+[exec:fish] exec git status --porcelain
+[exec:fish] cmp stdout ../expected-porcelain.txt
+[exec:fish] cd ..
+
+-- repo_base/bar.foo --
+ab
+-- repo_base/foo.bar --
+ab
+-- bar.foo.modified --
+abcd
+-- foo.bar.modified --
+abcd
+-- expected-porcelain.txt --
+ M foo.bar


### PR DESCRIPTION
Pretty much as it says on the tin.

`git stash push` (optionally) also takes path(s) for its arguments, so translate them.