### PR TITLE
fix: escape Windows path separators

### DIFF
--- a/internal/cmd/expand/expand.go
+++ b/internal/cmd/expand/expand.go
@@ -32,7 +32,7 @@ Takes a list of digits (1 4 5) or numeric ranges (1-5) or even both.`,
 	return expandCmd
 }
 
-var shellEscaper = regexp.MustCompile("([\\^()\\[\\]<>' \";\\|*])")
+var shellEscaper = regexp.MustCompile(`([\\()\[\]<>' ";|*^])`)
 
 // Process expands args and performs all substitution, etc.
 //

--- a/internal/cmd/expand/expand_test.go
+++ b/internal/cmd/expand/expand_test.go
@@ -27,6 +27,7 @@ func TestProcessEscaping(t *testing.T) {
 		{name: "quote escaped", value: "\"x.txt", want: "\\\"x.txt"},
 		{name: "semicolon escaped", value: "wt;af.gif", want: "wt\\;af.gif"},
 		{name: "pipe escaped", value: "foo|bar", want: "foo\\|bar"},
+		{name: "windows path separators escaped", value: `dir\readme.md`, want: `dir\\readme.md`},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #10.

## Summary
- Escapes backslashes when expanding numeric shortcuts so Windows-style paths are not collapsed by the shell.
- Adds a regression test covering `dir\readme.md` expansion output.

## Verification
- `go test ./internal/cmd/expand`
- `go test -short ./internal/cmd/expand ./internal/arguments`
- `go test -short ./internal/cmd/status -run 'TestRenderer_Display/.*/display.plain|TestRenderer_Display/.*/parsedata'`\n- `git diff --check`\n\n## Notes\n- `make test` / `go test ./...` still fail in this non-interactive environment on existing `internal/cmd/status` ANSI golden cases because colorized output is not emitted; plain and parse-data renderer cases pass.\n- `make lint` could not run because `golangci-lint` is not installed in this environment.\n\n## AI assistance\nAI assistance was used to prepare this change. I reviewed the diff, scoped it to the shell escaping path, and verified it with the commands above.