### PR TITLE
fix: expand numeric arg after bundled message flag (e.g. -am)

### DIFF
--- a/internal/arguments/arguments.go
+++ b/internal/arguments/arguments.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -68,6 +69,10 @@ func convertToRelativeIfFilePath(arg string) (string, error) {
 // value must be glued (e.g. "-U3") are not a problem because the combined
 // token doesn't match the digit regex.
 //
+// Short flags may also be bundled into a single token, with the value-taking
+// flag last (e.g. "git commit -am 205" is "-a -m 205", so "205" is the
+// message). We detect this for the message flag via isBundledMessageFlag.
+//
 // Known limitation: positional numeric arguments that don't immediately follow
 // a flag (e.g. the start-point in "git checkout -b new 713") are not protected.
 //
@@ -86,14 +91,16 @@ func skipExpansion(args []string, pos int, gitCmd string) bool {
 		}
 	case "commit":
 		switch prev {
-		case "-m", "--message":
+		case "--message":
 			return true
 		}
+		return isBundledMessageFlag(prev)
 	case "merge":
 		switch prev {
-		case "-m", "--message":
+		case "--message":
 			return true
 		}
+		return isBundledMessageFlag(prev)
 	case "checkout":
 		switch prev {
 		case "-b", "-B", "--orphan":
@@ -111,6 +118,21 @@ func skipExpansion(args []string, pos int, gitCmd string) bool {
 		}
 	}
 	return false
+}
+
+// isBundledMessageFlag reports whether flag is a short-flag token whose final
+// letter is "m" — the message flag for "git commit"/"git merge". This covers
+// the plain "-m" as well as bundled forms like "-am" or "-sam" (common via
+// aliases such as "gcam" => "git commit -am"), where the token after the flag
+// is the message and must not be expanded as a file shortcut.
+//
+// It deliberately excludes long flags ("--foo") and glued values ("-m205",
+// which git reads as the message "205" in the same token, so there is no
+// separate token to protect).
+func isBundledMessageFlag(flag string) bool {
+	return strings.HasPrefix(flag, "-") &&
+		!strings.HasPrefix(flag, "--") &&
+		strings.HasSuffix(flag, "m")
 }
 
 // Expand takes the list of arguments received from the command line and expands

--- a/internal/arguments/arguments_test.go
+++ b/internal/arguments/arguments_test.go
@@ -59,6 +59,16 @@ var testExpandNumericFlagCases = []struct {
 	{"git commit --message 456", "git commit --message 456"},
 	{"git merge -m 123 topic", "git merge -m 123 topic"},
 
+	// Bundled short flags where the message flag "-m" is last in the cluster
+	// (e.g. the common "gcam" alias => "git commit -am"). The following token
+	// is the message and must not be expanded.
+	{"git commit -am 205", "git commit -am 205"},
+	{"git commit -sam 205", "git commit -sam 205"},
+	{"git merge -am 205 topic", "git merge -am 205 topic"},
+	// The "m" must be last: in "-ma" it is not the message flag, so a trailing
+	// numeric token is still a file shortcut.
+	{"git commit -ma 1", "git commit -ma $e1"},
+
 	// Flags where the value is glued to the flag (no space) — the combined
 	// token won't match the digit regex, so expansion is already harmless.
 	{"git log -n1 2", "git log -n1 $e2"},


### PR DESCRIPTION
## Problem

Running `gcam "205"` (where `gcam` aliases to `git commit -am`) aborts with **"Aborting commit due to empty commit message."**

`skipExpansion` protects flag values from being turned into file shortcuts, but it only recognized the *exact* tokens `-m` and `--message`. The bundled short-flag cluster `-am` (i.e. `-a -m` combined, very common via aliases) wasn't recognized, so `205` was expanded into `$e205` — an unset variable → empty string → git aborts.

The plain `git commit -m 205` / `--message 205` cases already worked; only the bundled form was broken.

## Fix

Added `isBundledMessageFlag`, which recognizes any short-flag token ending in `m` (`-m`, `-am`, `-sam`, …) as taking the following token as the commit/merge message. Long flags (`--message`, matched exactly) and glued values (`-m205`) are correctly excluded.

## Tests

Added cases to `testExpandNumericFlagCases`: `-am 205`, `-sam 205`, `merge -am 205 topic`, plus a negative case `-ma 1` (where `m` isn't last, so the trailing `1` is still a file shortcut).

Verified end-to-end: `git commit -am 205` now commits with message `205`.

Fixes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)